### PR TITLE
Add adjusted random generation for syllable element type.

### DIFF
--- a/src/classes/default.js
+++ b/src/classes/default.js
@@ -36,13 +36,16 @@ const options = {
             preventDouble: ['j','w','th','sh']
         },
         other: {
-            maxWordLength: 5,
+            maxWordLength: 3
         },
         inventorySimple: {
             C: ['b', 'c', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'p', 'q', 'r', 's', 't', 'v', 'w', 'x', 'z'],
             V: ['a', 'e', 'i', 'o', 'u']
         },
         phonotacticsSimple: ['CVC']
+    },
+    config: {
+        adjustTypes: 2
     },
     names: {
         firstNames: {

--- a/src/classes/language.js
+++ b/src/classes/language.js
@@ -136,7 +136,7 @@ class Language {
      * @param {number} length Word length in syllables. Default: random integer between 1 and {@link langOptions.phonology.other.maxWordLength}.
      * @returns {string} Random word.
      */
-    Word(length = random.int(this.phonology.other.maxWordLength-1)+1) {
+    Word(length = random.int(this.phonology.other.maxWordLength)+1) {
         if (!this.phonology.inventory) {
             return;
         }
@@ -218,80 +218,49 @@ class Language {
         return convertedSentences.join(' ');
     }
 
-    // Simple syllable generation
-    SyllableSimple(pattern = random.pick(this.phonology.phonotacticsSimple)) {
-        var syllable = [];
-        var sylElList = pattern.split('');
-        sylElList.forEach(syllableElement => {
-            var index = random.int(this.phonology.inventorySimple[syllableElement].length);
-            var character = this.phonology.inventorySimple[syllableElement][index];
-            syllable = syllable.concat(character);
-        });
-        return syllable.join('');
-    }
-    // Simple word generation
-    WordSimple(length = random.int(2) + 1) {
-        var word = '';
-        for (var i = 0; i < length; i++) {
-            word = word.concat(this.SyllableSimple());
-        }
-        return word;
-    }
-
-    // Generate first name
-    FirstName(type = random.pick(Object.keys(this.names.firstNames))) {
-        var pattern = random.pick(this.names.firstNames[type]);
-        var name = _.capitalize(this.SyllableSimple(pattern));
-        return name;
-    }
-
-    // Generate full name
-    FullName(type = random.pick(Object.keys(this.names.firstNames))) {
-        var firstName = this.FirstName(type);
-        var lastName = _.capitalize(this.WordSimple());
-        var fullName = `${firstName  } ${  lastName}`;
-        return `${fullName  } (${  type  })`;
-    }
-
     /**
      * Regenerates onset if non-empty coda is followed by liquid onset.
      * @param {Syllable[]} word
      */
     CheckLiquid(word) {
-        // Check if 
+        var processedWord = word;
         for (var i = 0; i < word.length; i++) {
-            if (i != word.length - 1 && word[i].coda.type != '' && word[i + 1].onset.type == 'liquids') {
+            if (i != word.length - 1 && word[i].coda.type != '' && word[i + 1].onset.type[1] == 'liquids') {
                 // Generate a syllable with non-liquid onset
-                word[i + 1].ChangeElementType('onset');
+                processedWord[i + 1].ChangeElementType('onset');
             }
         }
-        return word;
+        return processedWord;
     }
+
     /**
      * Regenerates onset if non-empty coda is followed by glide onset.
      * @param {Syllable[]} word
      */
     CheckGlide(word) {
+        var processedWord = word;
         for (var i = 0; i < word.length; i++) {
-            if (i != word.length - 1 && word[i].coda.type != '' && word[i + 1].onset.type == 'glides') {
+            if (i != word.length - 1 && word[i].coda.type != '' && word[i + 1].onset.type[1] == 'glides') {
                 // Generate a syllable with non-glide onset
-                word[i + 1].ChangeElementType('onset');
+                processedWord[i + 1].ChangeElementType('onset');
             }
         }
-        return word;
+        return processedWord;
     }
+
     /**
      * Regenerates onset if empty coda is followed by empty onset
      * @param {any} word
      */
     CheckDoubleNucleus(word) {
+        var processedWord = word;
         for (var i = 0; i < word.length; i++) {
-            if (i != word.length - 1 && word[i].coda.type == '' && word[i + 1].onset.type == '') {
+            if (i != word.length - 1 && word[i].coda.type[1] == undefined && word[i + 1].onset.type[1] == undefined) {
                 // Generate a syllable with non-empty onset
-                word[i + 1].ChangeElementType('onset');
+                processedWord[i + 1].ChangeElementType('onset');
             }
         }
-        return word;
+        return processedWord;
     }
 
 }

--- a/src/classes/syllable.js
+++ b/src/classes/syllable.js
@@ -1,6 +1,4 @@
 // Modules
-const _ = require('lodash');
-const Language = require('./language');
 const defaultOptions = require('./default.js');
 const random = require('../util/random.js');
 
@@ -17,6 +15,7 @@ class Syllable {
         elements = {}
     ) {
         this.options = options;
+        this.pow = (this.options.config && this.options.config.adjustTypes) ? this.options.config.adjustTypes : 1;
 
         /**
          * Syllable element.
@@ -54,7 +53,7 @@ class Syllable {
         if (type && this.options.phonology.phonotactics.onsets.includes(type)) {
             onsetType = type;
         } else {
-            onsetType = random.pick(this.options.phonology.phonotactics.onsets);
+            onsetType = random.pickAdj(this.options.phonology.phonotactics.onsets, this.pow);
         }
         var onsetText = onsetType.length ? random.pick(this.options.phonology.inventory[onsetType[0]][onsetType[1]]) : '';
         return {
@@ -74,7 +73,7 @@ class Syllable {
         if (type && this.options.phonology.phonotactics.nuclei.includes(type)) {
             nucleusType = type;
         } else {
-            nucleusType = random.pick(this.options.phonology.phonotactics.nuclei);
+            nucleusType = random.pickAdj(this.options.phonology.phonotactics.nuclei, this.pow);
         }
         var nucleusText = nucleusType.length ? random.pick(this.options.phonology.inventory[nucleusType[0]][nucleusType[1]]) : '';
         return {
@@ -94,7 +93,7 @@ class Syllable {
         if (type && this.options.phonology.phonotactics.codas.includes(type)) {
             codaType = type;
         } else {
-            codaType = random.pick(this.options.phonology.phonotactics.codas);
+            codaType = random.pickAdj(this.options.phonology.phonotactics.codas, this.pow);
         }
         var codaText = codaType.length ? random.pick(this.options.phonology.inventory[codaType[0]][codaType[1]]) : '';
         return {
@@ -117,25 +116,25 @@ class Syllable {
         var oldElementType;
         var newElementType;
         var newElement;
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve) => {
             switch (element) {
                 case 'onset':
                     oldElementType = this.onset.type;
-                    newElementType = random.pick(pt.onsets.filter(et => et != oldElementType));
+                    newElementType = random.pick(pt.onsets.filter(et => et[1] != oldElementType[1]));
                     newElement = this.GenerateOnset(newElementType);
                     this.onset = newElement;
                     resolve(newElement);
                     break;
                 case 'nucleus':
                     oldElementType = this.nucleus.type;
-                    newElementType = random.pick(pt.nuclei.filter(et => et != oldElementType));
+                    newElementType = random.pick(pt.nuclei.filter(et => et[1] != oldElementType[1]));
                     newElement = this.GenerateNucleus(newElementType);
                     this.nucleus = newElement;
                     resolve(newElement);
                     break;
                 case 'coda':
                     oldElementType = this.coda.type;
-                    newElementType = random.pick(pt.codas.filter(et => et != oldElementType));
+                    newElementType = random.pick(pt.codas.filter(et => et[1] != oldElementType[1]));
                     newElement = this.GenerateCoda(newElementType);
                     this.coda = newElement;
                     resolve(newElement);

--- a/src/tests/language.test.js
+++ b/src/tests/language.test.js
@@ -67,10 +67,18 @@ describe('Language.Syllable()', () => {
             expect(elvishSyl.options).toBe(Elvish.options);
         });
     });
+
+    describe('uses the correct adjustType', () => {
+        it('with default settings', () => {
+            var syl = new Language().Syllable();
+            expect(syl.pow).toEqual(defaultOptions.config.adjustTypes);
+        });
+    });
 });
 
 describe('Language.Word()', () => {
     var lang = new Language();
+
     describe('without parameters', () => {
         var word = lang.Word();
 
@@ -99,5 +107,137 @@ describe('Language.Text()', () => {
         it('returns a string', () => {
             expect(typeof txt).toBe('string');
         });
+    });
+});
+
+describe('constraints work', () => {
+    var lang = new Language();
+
+    test('liquid onsets after coda prevented', () => {
+        var syl1 = lang.Syllable(
+            {
+                onset: {
+                    type: ['consonants', 'affricates'],
+                    text: 'b'
+                },
+                nucleus: {
+                    type: ['vowels', 'low'],
+                    text: 'a'
+                },
+                coda: {
+                    type: ['consonants', 'approximants'],
+                    text: 'r'
+                }
+            },
+        );
+        var syl2 = lang.Syllable(
+            {
+                onset: {
+                    type: ['consonants', 'liquids'],
+                    text: 'gr'
+                },
+                nucleus: {
+                    type: ['vowels', 'high'],
+                    text: 'i'
+                },
+                coda: {
+                    type: ['consonants', 'nasals'],
+                    text: 'm'
+                }
+            });
+        var word = [syl1, syl2];
+        var newWord = lang.CheckLiquid(word);
+        expect(newWord[1].onset.type).not.toBe(['consonants', 'liquids']);
+    });
+
+    test('glide onsets after coda prevented', () => {
+        var syl1 = lang.Syllable(
+            {
+                onset: {
+                    type: ['consonants', 'affricates'],
+                    text: 'b'
+                },
+                nucleus: {
+                    type: ['vowels', 'low'],
+                    text: 'a'
+                },
+                coda: {
+                    type: ['consonants', 'approximants'],
+                    text: 'r'
+                }
+            },
+        );
+        var syl2 = lang.Syllable(
+            {
+                onset: {
+                    type: ['consonants', 'glides'],
+                    text: 'hw'
+                },
+                nucleus: {
+                    type: ['vowels', 'high'],
+                    text: 'i'
+                },
+                coda: {
+                    type: ['consonants', 'nasals'],
+                    text: 'm'
+                }
+            });
+        var word = [syl1, syl2];
+        var newWord = lang.CheckGlide(word);
+        expect(newWord[1].onset.type).not.toBe(['consonants', 'glides']);
+    });
+
+    test('empty onset after empty coda prevented', () => {
+        var syl1 = lang.Syllable(
+            {
+                onset: {
+                    type: ['consonants', 'liquids'],
+                    text: 'dl'
+                },
+                nucleus: {
+                    type: ['vowels', 'low'],
+                    text: 'a'
+                },
+                coda: {
+                    type: ['consonants','nasals'],
+                    text: 'm'
+                }
+            },
+        );
+        var syl2 = lang.Syllable(
+            {
+                onset: {
+                    type: [],
+                    text: ''
+                },
+                nucleus: {
+                    type: ['vowels', 'low'],
+                    text: 'a'
+                },
+                coda: {
+                    type: [],
+                    text: ''
+                }
+            }
+        );
+        var syl3 = lang.Syllable(
+            {
+                onset: {
+                    type: [],
+                    text: ''
+                },
+                nucleus: {
+                    type: ['vowels', 'low'],
+                    text: 'a'
+                },
+                coda: {
+                    type: [],
+                    text: ''
+                }
+            }
+        );
+        var word = [syl1, syl2, syl3];
+        var newWord = lang.CheckDoubleNucleus(word);
+        expect(newWord[2].onset.type).not.toBe([]);
     });
 });

--- a/src/tests/random.test.js
+++ b/src/tests/random.test.js
@@ -27,3 +27,25 @@ describe('random.pick(<array>)', () => {
         expect(array.includes(random.pick(array))).toBe(true);
     });
 });
+
+describe('random.pickAdj(<array>)', () => {
+    const array = ['Maedhros', 'Maglor', 'Celegorm', 'Caranthir', 'Curufin', 'Amrod', 'Amras'];
+
+    describe('with valid parameters', () => {
+        var res = random.pickAdj(array, 2);
+
+        it('returns a string', () => {
+            expect(typeof res).toBe('string');
+        });
+
+        it('picks a random element from <array>', () => {
+            expect(array.includes(res)).toBe(true);
+        });
+    });
+
+    it('works with invalid power parameters', () => {
+        expect(typeof random.pickAdj(array, 0)).toBe('string');
+        expect(typeof random.pickAdj(array, -2)).toBe('string');
+        expect(typeof random.pickAdj(array, 'thisIsNotEvenANumber')).toBe('string');
+    });
+});

--- a/src/util/random.js
+++ b/src/util/random.js
@@ -27,7 +27,21 @@ function PickRandom(array) {
     return array[index];
 }
 
+/**
+ * Pick a random element from an array. Prefers elements with lower index.
+ * @name pickAdj
+ * @param {any[]} array The array to pick from.
+ * @param {number} power The preference factor. Default value is 1, which represents equal chances. Higher power means stronger preference for lower indexes. Fraction power means preference for higher indexes. Defaults to 1 if set to negative value.
+ * @returns {any} The random element.
+ */
+function PickRandomAdjusted(array, power = 1) {
+    var powerToUse = (typeof power != 'number' || power <= 0) ? 1 : power;
+    const index = Math.floor(Math.pow(Math.random(), powerToUse) * array.length);
+    return array[index];
+}
+
 module.exports = {
     int: GetRandomInt,
-    pick: PickRandom
+    pick: PickRandom,
+    pickAdj: PickRandomAdjusted
 };


### PR DESCRIPTION
When picking a type for onset, nucleus and coda, the preference can be adjusted through langOptions.config.adjustType. A value of 1 means equal distribution, a higher value means preference for the beginning of the array, a fraction means preference for the end of the array.